### PR TITLE
Morton ND v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
-# Morton ND (N-dimensional)
+# Morton ND
 [![Build Status](https://travis-ci.org/kevinhartman/morton-nd.svg?branch=master)](https://travis-ci.org/kevinhartman/morton-nd) [![license](https://img.shields.io/github/license/mashape/apistatus.svg)](https://opensource.org/licenses/MIT)
 
-A C++14 header-only Morton encoding library for N dimensions. Includes a hardware-based approach (using Intel BMI2) for newer Intel CPUs, as well as another fast approach based on the Lookup Table (LUT) method for other CPU variants. 
+A header-only Morton encode/decode library (C++14) capable of encoding from and decoding to N-dimensional space. Includes a hardware-based approach (using Intel BMI2) for newer Intel CPUs, as well as another fast approach based on the Lookup Table (LUT) method for other CPU variants. 
+
+## Features
+All algorithms are **generated** at compile-time for the number of dimensions and field width used. This way, loops and branches are not required.
+
+### Encoding Support
+- any number of dimensions (e.g. `2D, 3D, 4D ... ND`).
+- built-in support for up to 128-bit native results (`__uint128_t`). Unlimited using a user-supplied "big integer" class.
+- `constexpr` encode method, allowing Morton encodings to be expressed at compile-time.
+
+### Decoder Support
+- any number of dimensions (bounded by native result width of 64).
+- built-in support for decoding up to 64-bit Morton codes.
+
+## Encoders and Decoders
 
 ### Hardware (Intel BMI2)
 Supports encoding and decoding in N dimensions, using Intel's BMI2 ISA extension (available in Haswell (Intel), Excavator (AMD) and newer).
@@ -41,7 +55,7 @@ Validation testing specific to MortonND is located in the `tests` folder, coveri
 Performance benchmark tests (and additional validation) for 2D and 3D use cases are located in a separate repository. See [this fork](https://github.com/kevinhartman/libmorton#fork-changes) of @Forceflow's [Libmorton](https://github.com/Forceflow/libmorton), which integrates Morton ND into Libmorton's existing test framework.
 
 ### Benchmarks
-The snippets below show performance comparisons between various 3D configurations of Morton ND, as well as comparisons to the 3D algorithms found in Libmorton.
+The snippets below show performance comparisons between various 3D configurations of Morton ND. Comparisons to the 3D algorithms found in Libmorton are also included to demonstrate that Morton ND's generated algorithms are as efficient as hand-coded algorithms.
 
 To run these tests (and more!) on your own machine, clone the fork linked above.
 

--- a/docs/MortonND_BMI2.md
+++ b/docs/MortonND_BMI2.md
@@ -1,14 +1,14 @@
 # Morton ND BMI2 Usage Guide
 The `MortonNDBmi` class can be used to encode and decode `32` and `64` bit width fields in N dimensions using the BMI2 instruction set, available on modern x64 CPUs (Haswell (Intel), Excavator (AMD) and newer).
 
-Configure the class by providing the number of fields `Fields` followed by the result type `T` (either `uint32_t` or `uint64_t`) as template parameters.
+Configure the class by providing the number of fields `Dimensions` followed by the result type `T` (either `uint32_t` or `uint64_t`) as template parameters.
 
-The number of bits used (starting with the LSb) of each input field provided to the `Encode` function (and conversely, returned from the `Decode` function) is calculated as `⌊bits in T / Fields⌋`. Any higher-order bits will be ignored during an encode and will be `0` during a decode. For this reason, it is not necessary to mask off high-order bits.
+The number of bits used (starting with the LSb) of each input field provided to the `Encode` function (and conversely, returned from the `Decode` function) is calculated as `⌊bits in T / Fields⌋`. Any higher-order bits will be ignored during an encode and will be `0` during a decode. For this reason, **it is not necessary to mask off high-order bits.**
 
 For diagnostic purposes, the member `FieldBits` provides the number of bits considered in each field. For example, `MortonNDBmi<3, uint64_t>::FieldBits` will return `21`.
 
 ### Encoding
-The encode function is variadic, but will assert that exactly `Fields` fields are specified. 
+The encode function is variadic, but will assert that exactly `Dimensions` fields are specified. 
 
 ```c++
 // 32-bit 3D, 10 bits per field (MortonNDBmi<3, uint32_t>::FieldBits == 10)

--- a/docs/MortonND_LUT.md
+++ b/docs/MortonND_LUT.md
@@ -1,16 +1,16 @@
 # Morton ND LUT Usage Guide
 The `MortonNDLutEncoder` class encapsulates a LUT and provides a corresponding encode function. To instantiate it, you must specify the number of fields (N), the number of bits in each field (starting with the least significant bit), and the size of the LUT as template parameters. LUT size is expressed as the number of bits which will be looked up at a time (chunk size). For example, a LUT size of 16 yields a LUT with 2^16 entries, allowing 16 bit lookups.
 
-To create a `MortonNDLutEncoder` to accommodate N fields, each Q bits, parameterize it with `N` for `Fields`,  and `Q` for `FieldBits`. Use the third template parameter, `LutBits`, to specify the width of each lookup chunk.
+To create a `MortonNDLutEncoder` to accommodate `N` fields, each `Q` bits, parameterize it with `Dimensions = N`  and `FieldBits = Q`. Use the third template parameter, `LutBits`, to specify the width of each lookup chunk.
 
 At both extremes, a  `LutBits` value equal to `FieldBits` will result in a single lookup (1 chunk), whereas a value of `1` will result in `|FieldBits|` lookups (`|FieldBits|` chunks). For every additional chunk, additional bit manipulation operations will be required to combine results (increasing encode time), however, the `MortonNDLutEncoder` class was written with compiler optimization in mind and should not introduce additional function calls. The number of chunks which will be used based on your configuration is exposed as a static member field (`MortonNDLutEncoder<...>::ChunkCount`) to aid in performance debugging.
 
 While large LUTs offer the least bit manipulation overhead, they have a few drawbacks: compilation time increases significantly with larger values, they take up more space in the program image / executable, and they can be slower than smaller LUTs due to cache misses, depending on the domain's access pattern.
 
-<blockquote>
-<b>Note:</b></p>
-The max LUT size is 24 when compiled with GCC (8.1), 25 for Clang (900.0.39.2), and 10 for MSVC (1915). See the notes section below on various compiler limitations.
-</blockquote>
+>
+> **Note:**
+>
+> The max LUT size is 24 when compiled with GCC (8.1), 25 for Clang (900.0.39.2), and 10 for MSVC (1915). See the notes section below on various compiler limitations.
 
 ### Encoding
 Once you've instantiated a `MortonNDLutEncoder`, use its `Encode` function to encode inputs. The encode function is variadic, but will assert that exactly N fields are specified. Note that this function is also marked `constexpr` and can be used in compile-time expressions.

--- a/morton-nd/include/mortonND_BMI2.h
+++ b/morton-nd/include/mortonND_BMI2.h
@@ -1,11 +1,16 @@
 //
-// Created by Kevin Hartman on 8/6/18.
+//  mortonND_BMI2.h
+//  morton-nd
+//
+//  Copyright (c) 2015 Kevin Hartman.
 //
 
 #ifndef MORTON_ND_MORTONND_BMI2_H
 #define MORTON_ND_MORTONND_BMI2_H
 
 #if defined(__BMI2__) || __AVX2__
+#define MORTON_ND_BMI2_ENABLED 1
+
 #include <array>
 #include <cmath>
 #include <limits>
@@ -13,44 +18,120 @@
 #include <type_traits>
 #include <immintrin.h>
 
-namespace mortonnd{
+namespace mortonnd {
 
-template<std::size_t Fields, typename T,
-    typename = std::enable_if_t<std::is_same<T, uint32_t>::value | std::is_same<T, uint64_t>::value>>
+/**
+ * Returns a selector mask to be used by 'pdep' and 'pext' intrinsic operations.
+ *
+ * This value is a repeating string of 'BitsRemaining' 1s separated by 'fields' - 1
+ * 0s, starting with the least-significant-bit set.
+ *
+ * Example:
+ * BuildSelector<6>(3) => 1001001001001001
+ *
+ * @tparam BitsRemaining the number of 1-bits to include in the mask.
+ * @param fields the stride of the 1 bits in the mask.
+ * @return the selector mask suitable for use by 'pdep' and 'pext'
+ */
+template<std::size_t BitsRemaining>
+constexpr uint64_t BuildSelector(std::size_t fields) {
+    return (BuildSelector<(BitsRemaining - 1)>(fields) << fields) | 1UL;
+}
+
+/**
+ * Special case to avoid shifting >= width of uint64_t.
+ */
+template<>
+constexpr uint64_t BuildSelector<1>(std::size_t) {
+    return 1UL;
+}
+
+/**
+ * A fast N-dimensional Morton encoder/decoder for targets supporting BMI2/AVX2 instruction
+ * set extensions.
+ *
+ * This implementation supports up to 64-bit encodings. If you need support for larger results,
+ * consider using 'MortonNDLutEncoder' which can support 128-bit results natively, or even
+ * larger results using a custom BigInteger-like class.
+ *
+ * Configuration:
+ *
+ * Dimensions
+ *   You must define the number of dimensions (number of inputs) that encoder/decoder
+ *   invocations will require via template parameter. The static 'Encode' function will require
+ *   exactly this number of inputs to be provided.
+ *
+ * T
+ *   The type of the components to encode/decode, as well as the result. This must be either 'uint32_t'
+ *   or 'uint64_t', since the underlying BMI instructions only operate on 32 and 64 bit fields.
+ *
+ * @tparam Dimensions the number of fields (components) to encode.
+ * @tparam T the type of the components to encode/decode, as well as the type of the result.
+ *         Must be either uint32_t or uint64_t.
+ */
+template<std::size_t Dimensions, typename T>
 class MortonNDBmi
 {
 public:
-    static const std::size_t FieldBits = std::numeric_limits<T>::digits / Fields;
+    static constexpr auto FieldBits = std::size_t(std::numeric_limits<T>::digits) / Dimensions;
 
-    template<typename...Args, typename std::enable_if<sizeof...(Args) == Fields - 1, int>::type = 0>
+    static_assert(Dimensions > 0, "'Dimensions' must be > 0.");
+    static_assert(std::is_same<T, uint32_t>::value | std::is_same<T, uint64_t>::value,
+        "'T' must be either uint32_t or uint64_t.");
+
+    /**
+     * Calculates the Morton encoding of the specified input fields by interleaving the bits
+     * of each. The first bit (LSb) of each field in the interleaved result starts at its offset in
+     * the parameter list.
+     *
+     * WARNING: Inputs must NOT use more than 'FieldBits' least-significant bits.
+     *
+     * Example:
+     *   Encode(xxxxxxxx, yyyyyyyy, zzzzzzzz) => zyxzyxzyxzyxzyxzyxzyxzyx
+     *
+     * Field X starts at offset 0 (the LSb of the result)
+     * Field Y starts at offset 1
+     * Field Z starts at offset 2
+     *
+     * @param field0 the first field (will start at offset 0 in the result)
+     * @param fields the rest. Must be convertible to 'T' without precision loss for a correct result.
+     * @return the calculated Morton code.
+     */
+    template<typename...Args>
     static inline T Encode(T field1, Args... fields)
     {
+        static_assert(sizeof...(Args) == Dimensions - 1, "'Encode' must be called with exactly 'Dimensions' arguments.");
         return EncodeInternal(field1, fields...);
     }
 
+    /**
+     * Decodes a Morton code by de-interleaving it into its components.
+     *
+     * Example:
+     *   Decode(zyxzyxzyxzyxzyxzyxzyxzyx) => std::tuple { xxxxxxxx, yyyyyyyy, zzzzzzzz }
+     *
+     * @param encoding the Morton code to decode.
+     * @return a tuple containing the code's individual components.
+     */
     static inline auto Decode(T encoding)
     {
-        return DecodeInternal(encoding, std::make_index_sequence<Fields>{});
+        return DecodeInternal(encoding, std::make_index_sequence<Dimensions>{});
     }
 
 private:
     MortonNDBmi() = default;
 
-    static constexpr T BuildSelector(size_t bitsRemaining) {
-        return bitsRemaining == 1 ? 1 : (BuildSelector(bitsRemaining - 1) << Fields) | 1;
-    }
-
-    static const auto Selector = BuildSelector(FieldBits);
+    static const T Selector = BuildSelector<FieldBits>(Dimensions);
 
     template<typename...Args>
     static inline T EncodeInternal(T field1, Args... fields)
     {
-        return EncodeInternal(fields...) | Deposit<Fields - sizeof...(fields) - 1>(field1);
+        return EncodeInternal(fields...) | Deposit<Dimensions - sizeof...(fields) - 1>(field1);
     }
 
     static inline T EncodeInternal(T field)
     {
-        return Deposit<Fields - 1>(field);
+        return Deposit<Dimensions - 1>(field);
     }
 
     template<size_t... i>
@@ -79,7 +160,36 @@ private:
         return _pext_u64(encoding, Selector << FieldIndex);
     }
 };
+
+/**
+ * Type alias for 2D encodings that fit in a 32-bit result.
+ *
+ * Inputs must NOT use more than 16 least-significant bits.
+ */
+using MortonNDBmi_2D_32 = MortonNDBmi<2, uint32_t>;
+
+/**
+ * Type alias for 2D encodings that fit in a 64-bit result.
+ *
+ * Inputs must NOT use more than 32 least-significant bits.
+ */
+using MortonNDBmi_2D_64 = MortonNDBmi<2, uint64_t>;
+
+/**
+ * Type alias for 3D encodings that fit in a 32-bit result.
+ *
+ * Inputs must NOT use more than 10 least-significant bits.
+ */
+using MortonNDBmi_3D_32 = MortonNDBmi<3, uint32_t>;
+
+/**
+ * Type alias for 3D encodings that fit in a 64-bit result.
+ *
+ * Inputs must NOT use more than 21 least-significant bits.
+ */
+using MortonNDBmi_3D_64 = MortonNDBmi<3, uint64_t>;
+
 }
 
 #endif
-#endif //MORTON_ND_MORTONND_BMI2_H
+#endif

--- a/morton-nd/include/mortonND_LUT_encoder.h
+++ b/morton-nd/include/mortonND_LUT_encoder.h
@@ -2,8 +2,7 @@
 //  mortonND_encoder.h
 //  morton-nd
 //
-//  Created by Kevin Hartman on 2/23/15.
-//  Copyright (c) 2015 Kevin Hartman. All rights reserved.
+//  Copyright (c) 2015 Kevin Hartman.
 //
 
 #ifndef mortonND_encoder_h
@@ -15,53 +14,255 @@
 #include <type_traits>
 #include <limits>
 
-namespace mortonnd{
+namespace mortonnd {
 
-template<size_t Size, typename Default = void()>
-using built_in_t =
-    typename std::conditional<(Size <= std::numeric_limits<uint8_t>::digits), uint8_t,
-        typename std::conditional<(Size <= std::numeric_limits<uint16_t>::digits), uint16_t,
-            typename std::conditional<(Size <= std::numeric_limits<uint32_t>::digits), uint32_t,
-                typename std::conditional<(Size <= std::numeric_limits<uint64_t>::digits), uint64_t, Default>
+/**
+ * Resolves to the narrowest native unsigned integer type that is at
+ * least 'Bits' wide.
+ *
+ * If no native type can handle the requested width, this becomes type
+ * 'void()', which will fail compilation when substituted later.
+ *
+ * This is used as the LutValue type to ensure that the lookup table
+ * is as small as possible (and to improve cache hits in subsequent
+ * lookups).
+ *
+ * Note:
+ * For current use cases (i.e. as LutValue), a value 'Bits' > 64
+ * will not be requested (it's guarded against by a static assertion).
+ */
+template<size_t Bits>
+using MinInt =
+    typename std::conditional<(Bits <= 8), uint_least8_t,
+        typename std::conditional<(Bits <= 16), uint_least16_t,
+            typename std::conditional<(Bits <= 32), uint_least32_t,
+                typename std::conditional<(Bits <= 64), uint_least64_t, void()>
                     ::type>::type>::type>::type;
 
 /**
- * @param Fields the number of fields (components) to encode
+ * Resolves to the fastest *non-implicitly-promotable* native unsigned
+ * integer type that is at least 'Bits' wide, or 'Default' if no such
+ * type exists.
+ *
+ * This is used to select the interface type (T) used for encoding
+ * inputs as well as the result.
+ *
+ * Note:
+ * It's important that this type is not implicitly promotable to a
+ * *signed* integer type, which could produce incorrect results.
+ *
+ * Signed types could be supported with input masking, but this would
+ * add extra overhead.
+ */
+template<size_t Bits, typename Default = void()>
+using FastInt =
+    typename std::conditional<(Bits <= 32), uint_fast32_t,
+        typename std::conditional<(Bits <= 64), uint_fast64_t, Default>
+            ::type>::type;
+
+/**
+ * The mapping function used by lookup table generation.
+ *
+ * Maps unsigned integers to their "split" form.
+ *
+ * This is done by taking the binary representation of 'input' and
+ * injecting 'fields' - 1 padding bits between each bit.
+ *
+ * Example:
+ *   7 (dec) => 111 (bin) => 1001001 (bin) => 73 (dec)
+ *
+ * @tparam BitsRemaining the number of least-significant-bits left to process.
+ * @param input the integer to distribute over the result.
+ * @param fields the stride between value bits.
+ * @return the lookup table value for 'input'
+ */
+template<std::size_t BitsRemaining>
+constexpr auto SplitByN(std::size_t input, std::size_t fields) {
+    return (SplitByN<BitsRemaining - 1>(input >> 1U, fields) << fields) | (input & 1U);
+}
+
+/**
+ * Special case to avoid shifting >= width of 'input'.
+ */
+template<>
+constexpr auto SplitByN<1>(std::size_t input, std::size_t) {
+    return input & 1U;
+}
+
+/**
+ * A fast portable N-dimensional LUT-based Morton encoder.
+ *
+ * This class literal (constexpr class) generates a suitable LUT (based on template parameters)
+ * along with an efficient (i.e. no func calls, no branches) Morton encoding algorithm.
+ *
+ * This implementation supports up to 128-bit encodings using native integer types, but
+ * can be also be used with user-provided encoding types (e.g. a BigInteger class) to support
+ * encodings of any size. Note that user-provided encoding types must behave like standard C++
+ * unsigned integers.
+ *
+ * For most use-cases (i.e. when the encoding result can fit within a 64-bit unsigned integer),
+ * it should be sufficient to omit the encoding type altogether (a suitable native unsigned
+ * integer type will be selected automatically).
+ *
+ * Configuration:
+ *
+ * Dimensions
+ *   You must define the number of dimensions (number of inputs) with which this encoder instance
+ *   will be used via template parameter. The resulting instance's 'Encode' function will require
+ *   exactly this number of inputs to be provided.
+ *
+ * FieldBits
+ *   The number of bits (least-significant) in each field must also be provided via template
+ *   parameter. For example, if encoding N 10-bit fields, this would be 10. While other Morton
+ *   encoding libraries do not require this information, Morton ND uses it to perform
+ *   compile-time optimizations, such as early termination.
+ *
+ *   WARNING: results will be incorrect if encoder input values exceed this width.
+ *
+ * LutBits
+ *   The LUT lookup width (in bits) must be provided as a template parameter. This is perhaps
+ *   the most interesting parameter, since it allows the generated LUT and algorithm to be tuned
+ *   for a particular CPU target and application.
+ *
+ *   This value dictates the size of the generated lookup table, as well as the number of lookups
+ *   performed by the generated 'Encode' function.
+ *
+ *   LUT size in memory will be:    2^^LutBits * sizeof(LutValue)
+ *   Look-ups per Encode call:      Dimensions * ChunkCount
+ *
+ *   Note: ChunkCount and LutValue are available as static members for debugging.
+ *
+ *   To properly tune this value, consider the following:
+ *
+ *   - A larger value will result in an exponentially larger LUT and exponentially higher
+ *     compilation times. For most use cases, 'LutBits' should not exceed 16.
+ *   - A larger value will result in an 'Encode' function with fewer operations ("faster"),
+ *     iff it reduces ChunkCount (inspect this with the ChunkCount static member).
+ *   - An 'Encode' function with minimal operations (see above) will not necessarily out-perform
+ *     one that does more (smaller LUT) due to CPU caching. Smaller LUT configurations tend to do
+ *     better for applications which call 'Encode' with random inputs. Larger configurations do
+ *     better when encoder inputs are close in value, or when consecutive calls to 'Encode'
+ *     include close values.
+ *
+ *   For performance critical applications, run benchmarks.
+ *
+ * T
+ *   The type of the components to encode, as well as the result. This is optional (the fastest type
+ *   which can fit the encoding result will be selected automatically), unless the requested config
+ *   would result in an encoding too big to fit in a 64-bit unsigned integer.
+ *
+ *   If you need support for a result width > 64 but <= 128, you may be able to provide '__uint128_t'
+ *   if your compiler supports it.
+ *
+ *   For > 128-bit results, a "BitInteger"-like class should work.
+ *
+ * @param Dimensions the number of fields (components) to encode.
  * @param FieldBits the number of bits in each input field, starting with the LSb. Higher bits are not cleared.
  * @param LutBits the number of bits for the LUT. Each field will be looked-up 'LutBits' bits at a time.
- * @param T the type of the components to encode/decode, as well as the type of the result
+ * @param T the type of the components to encode, as well as the type of the result.
  */
-template<std::size_t Fields, std::size_t FieldBits, std::size_t LutBits, typename T = built_in_t<Fields * FieldBits>>
+template<std::size_t Dimensions, std::size_t FieldBits, std::size_t LutBits, typename T = FastInt<Dimensions * FieldBits>>
 class MortonNDLutEncoder
 {
-    static_assert(Fields > 0, "Parameter 'Fields' must be > 0.");
-    static_assert(FieldBits > 0, "Parameter 'FieldBits' must be > 0. ");
-    static_assert(LutBits > 0, "Parameter 'LutBits' must be > 0.");
-    static_assert(LutBits <= FieldBits, "Parameter 'LutBits' must be <= 'FieldBits'.");
+    static constexpr auto LutValueWidth = LutBits * Dimensions;
 
-    // LUT entry size is always Fields * LutBits. If no suitable built-in type can hold the entry, the user-specified field
-    // type will be used (if provided).
-    using lut_entry_t = built_in_t<Fields * LutBits, T>;
+    static_assert(Dimensions > 0, "'Dimensions' must be > 0.");
+    static_assert(FieldBits > 0, "'FieldBits' must be > 0. ");
+    static_assert(LutBits > 0, "'LutBits' must be > 0.");
+    static_assert(LutBits <= FieldBits, "'LutBits' must be <= 'FieldBits'.");
+
+    // Note: there's no technical reason for '32', but a larger value would be unreasonable.
+    static_assert(LutBits <= 32, "'LutBits' must be <= 32.");
+
+    static_assert(LutValueWidth <= 64, "'LutBits' * 'Dimensions' must be <= 64.");
+    static_assert(LutValueWidth <= std::numeric_limits<std::size_t>::digits,
+        "'LutBits' * 'Dimensions' must be <= width of std::size_t.");
+
+    static_assert(!std::is_integral<T>::value || (std::numeric_limits<T>::digits >= (Dimensions * FieldBits)),
+        "'T' must be able to hold 'Dimensions' * 'FieldBits' bits (the result size).");
+
+    static_assert(!std::is_integral<T>::value || std::is_unsigned<T>::value,
+        "'T' must be unsigned.");
+
+    // LUT lookups require conversion from T to std::size_t. T's implementation of this
+    // should match that of standard C++ unsigned integral conversion.
+    //
+    // Note: this does not imply that T must fit within std::size_t.
+    static_assert(std::is_convertible<T, std::size_t>::value, "'T' must be convertible to std::size_t.");
 
 public:
+    /**
+     * The type used for encoding inputs as well as the result.
+     */
     typedef T type;
 
-    static const std::size_t ChunkCount = 1 + ((FieldBits - 1) / LutBits);
-    static const T InputMask = ((T)1 << FieldBits) - 1;
+    /**
+     * The number of chunks into which each input field is partitioned. This is also
+     * the number of LUT lookups performed for each field.
+     *
+     * For debugging / perf tuning.
+     */
+    static constexpr std::size_t ChunkCount = 1 + ((FieldBits - 1) / LutBits);
 
+    /**
+     * A mask which can be used to clear the upper bits of encoder inputs prior to
+     * a call to 'Encode', if they're expected to be dirty.
+     */
+    static constexpr T InputMask = ~std::size_t(0) >> (64U - FieldBits);
+
+    /**
+     * The type selected internally for the LUT's value.
+     * Will always accommodate Dimensions * LutBits bits.
+     *
+     * For debugging / perf tuning.
+     */
+    using LutValue = MinInt<LutValueWidth>;
+
+    /**
+     * Constexpr constructor.
+     *
+     * The resulting class literal instance holds the generated LUT (configurable via class
+     * template parameters) and provides an 'Encode' function which is optimized to perform
+     * encodings using that LUT.
+     *
+     * Note that the 'Encode' function is also constexpr, and can be used to produce encodings
+     * at compile-time.
+     */
     constexpr MortonNDLutEncoder() = default;
 
-    template<typename...Args, typename std::enable_if<sizeof...(Args) == Fields - 1, int>::type = 0>
-    constexpr T Encode(T field1, Args... fields) const
+    /**
+     * Calculates the Morton encoding of the specified input fields by interleaving the bits
+     * of each. The first bit (LSb) of each field in the interleaved result starts at its offset in
+     * the parameter list.
+     *
+     * Can be used in constant expressions.
+     *
+     * WARNING: Inputs must NOT use more than 'FieldBits' least-significant bits.
+     *          Use static member 'InputMask' to clear upper bits if necessary.
+     *
+     * Example:
+     * Encode(xxxxxxxx, yyyyyyyy, zzzzzzzz) => zyxzyxzyxzyxzyxzyxzyxzyx
+     *
+     * Field X starts at offset 0 (the LSb of the result)
+     * Field Y starts at offset 1
+     * Field Z starts at offset 2
+     *
+     * @param field0 the first field (will start at offset 0 in the result)
+     * @param fields the rest. Must be convertible to 'T' without precision loss for a correct result.
+     * @return the calculated Morton code.
+     */
+    template<typename...Args>
+    constexpr T Encode(T field0, Args... fields) const
     {
-        return EncodeInternal(field1, fields...);
+        static_assert(sizeof...(Args) == Dimensions - 1, "'Encode' must be called with exactly 'Dimensions' arguments.");
+        return EncodeInternal(field0, fields...);
     }
 
 private:
     template<typename...Args>
     constexpr T EncodeInternal(T field1, Args... fields) const
     {
-        return (EncodeInternal(fields...) << 1) | LookupField(field1, std::make_index_sequence<ChunkCount>{});
+        return (EncodeInternal(fields...) << 1U) | LookupField(field1, std::make_index_sequence<ChunkCount>{});
     }
 
     constexpr T EncodeInternal(T field) const
@@ -75,38 +276,77 @@ private:
     }
 
     template <typename ...Args>
-    constexpr T LookupField(T field, size_t, Args... args) const
+    constexpr T LookupField(T field, std::size_t, Args... args) const
     {
-        return (LookupField(field >> LutBits, args...) << (Fields * LutBits)) | (T)LookupTable[field & ChunkMask];
+        // Note: an implicit conversion from T to std::size_t will occur during
+        // table lookups, though precision loss will not occur (the value will
+        // not exceed that of ChunkMask (which has type std::size_t)).
+        return (LookupField(field >> LutBits, args...) << (Dimensions * LutBits)) | T(LookupTable[field & ChunkMask]);
     }
 
-    constexpr T LookupField(T field, size_t) const
+    constexpr T LookupField(T field, std::size_t) const
     {
         return LookupTable[field & ChunkMask];
     }
 
-    static constexpr lut_entry_t SplitByN(lut_entry_t input, size_t bitsRemaining = LutBits) {
-        return (bitsRemaining == 1)
-            ? (input & (lut_entry_t)1)
-            : (SplitByN(input >> 1, bitsRemaining - 1) << Fields) | (input & (lut_entry_t)1);
+    // NOTE: this is implemented at namespace level due to CWG727.
+    // http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#727
+    static constexpr LutValue SplitByN(std::size_t input) {
+        return mortonnd::SplitByN<LutBits>(input, Dimensions);
     }
 
     template<size_t... i>
-    static constexpr auto BuildLut(std::index_sequence<i...>) {
-        return std::array<lut_entry_t, sizeof...(i)>{{SplitByN(i)...}};
+    static constexpr auto BuildLut(std::index_sequence<i...>) noexcept {
+        return std::array<LutValue, sizeof...(i)>{{SplitByN(i)...}};
     }
 
-    static constexpr size_t pow(size_t base, size_t exp) {
+    static constexpr std::size_t pow(std::size_t base, std::size_t exp) {
         return exp == 0 ? 1 : base * pow(base, exp - 1);
     }
 
-    static constexpr size_t ComputeLutSize() {
+    static constexpr std::size_t ComputeLutSize() {
         return pow(2, LutBits);
     }
 
-    static const size_t LutSize = ComputeLutSize();
-    static const T ChunkMask = ((T)1 << LutBits) - 1;
-    const std::array<lut_entry_t, LutSize> LookupTable = BuildLut(std::make_index_sequence<LutSize>{});
+    static constexpr std::size_t LutSize = ComputeLutSize();
+    static constexpr std::size_t ChunkMask = ~std::size_t(0) >> (64U - LutBits);
+    const std::array<LutValue, LutSize> LookupTable = BuildLut(std::make_index_sequence<LutSize>{});
 };
-} // namespace mortonnd
+
+// Note: The below type aliases define default configurations for common use-cases,
+//       including 2D and 3D encodings that fit in 32 and 64 bit results.
+//
+//       The defaulted 'LUTBits' values attempt to reduce LUT look-up operations
+//       while keeping LUT table sizes relatively small to: take advantage of caching,
+//       keep programs small, and minimize build times.
+
+/**
+ * Type alias for 2D encodings that fit in a 32-bit result.
+ *
+ * Inputs must NOT use more than 16 least-significant bits.
+ */
+using MortonNDLutEncoder_2D_32 = MortonNDLutEncoder<2, 16, 8>;
+
+/**
+ * Type alias for 2D encodings that fit in a 64-bit result.
+ *
+ * Inputs must NOT use more than 32 least-significant bits.
+ */
+using MortonNDLutEncoder_2D_64 = MortonNDLutEncoder<2, 32, 11>;
+
+/**
+ * Type alias for 3D encodings that fit in a 32-bit result.
+ *
+ * Inputs must NOT use more than 10 least-significant bits.
+ */
+using MortonNDLutEncoder_3D_32 = MortonNDLutEncoder<3, 10, 10>;
+
+/**
+ * Type alias for 3D encodings that fit in a 64-bit result.
+ *
+ * Inputs must NOT use more than 21 least-significant bits.
+ */
+using MortonNDLutEncoder_3D_64 = MortonNDLutEncoder<3, 21, 11>;
+
+}
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,9 @@ add_executable(morton-nd
 		mortonND_test.h
 		mortonND_BMI2_test.h
 		mortonND_LUT_encoder_test.h
-		variadic_placeholder.h
-		../morton-nd/include/mortonND_BMI2.h
-		../morton-nd/include/mortonND_LUT_encoder.h)
+		variadic_placeholder.h)
+
+target_include_directories(
+		morton-nd
+		PUBLIC ../morton-nd/include
+)

--- a/test/mortonND_BMI2_test.cpp
+++ b/test/mortonND_BMI2_test.cpp
@@ -2,7 +2,7 @@
 #include "mortonND_test_util.h"
 #include "mortonND_test_common.h"
 
-#include "../morton-nd/include/mortonND_BMI2.h"
+#include <mortonND_BMI2.h>
 
 template<typename Ret, typename ...Fields>
 bool TestMortonNDBmiEncoder(type_sequence<Fields...>) {

--- a/test/mortonND_LUT_encoder_test.cpp
+++ b/test/mortonND_LUT_encoder_test.cpp
@@ -1,8 +1,7 @@
+#include <mortonND_LUT_encoder.h>
 #include "mortonND_LUT_encoder_test.h"
 #include "mortonND_test_common.h"
 #include "variadic_placeholder.h"
-
-#include "../morton-nd/include/mortonND_LUT_encoder.h"
 
 template<size_t FieldBits, typename Ret, typename ...Fields, size_t ...FieldIdx, size_t ...N>
 bool TestMortonNDLutSet(type_sequence<Fields...>, std::index_sequence<FieldIdx...>, std::index_sequence<N...>) {


### PR DESCRIPTION
Changelog:

LUT Encoder
- Adds native support for 128-bit encode type / result.
- Adds support for user-defined encode types, which should allow for a "big integer"-like class to be used when > 128-bit encodings are desired. Note: this is currently untested. A future minor revision will introduce a sample project which uses such a class.
- Make LutValue type public in MortonNDLutEncoder to make debugging easier.
- Adds type aliases for common configurations: 2D and 3D in 32 and 64 bits.
- Encoding type (T) is now required to be >= 32 bit a signed integer, or a user-provided type. Previously, integer promotion of smaller encoding types could cause incorrect results.
- Limits LutBits value to 32 to prevent users from requesting something too unreasonable.
- Encoding type is now a fast integer when left up to automatic selection.
- LUT value type is now separate from encoding type and is always automatically selected as the smallest unsigned integer type which can fit LUT values (Dimensions * LutBits). Note that it's therefore no longer possible to specify a user-defined type as the LUT value type.
- Added interface documentation.
- Encode method parameter count is now enforced by a static assertion rather than SFINAE. This provides a better error message when a user provides the incorrect number of fields.
- Fixes a bug where ChunkCount could be over-shifted when LutBits was equal to the width of ChunkCount.
- Fixes a bug where a LUT value could be over-shifted during calculation.

BMI Encoder / Decoder
- Adds type aliases for common configurations: 2D and 3D in 32 and 64 bits.
- Fixes a bug in which the Selector could be over-shifted during calculation.
- Adds interface documentation.