### PR TITLE
CMake: make include file paths the same for BUILD_INTERFACE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(${PROJECT_NAME}::${MORTON_ND_LIBRARY_NAME} ALIAS ${MORTON_ND_LIBRARY
 # files are picked up from the GNUInstallDirs location when installed.
 target_include_directories(
         ${MORTON_ND_LIBRARY_NAME}
-        INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include/morton-nd>
+        INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_compile_features(${MORTON_ND_LIBRARY_NAME} INTERFACE cxx_std_14)

--- a/test/mortonND_BMI2_test.cpp
+++ b/test/mortonND_BMI2_test.cpp
@@ -2,7 +2,7 @@
 #include "mortonND_test_util.h"
 #include "mortonND_test_common.h"
 
-#include <mortonND_BMI2.h>
+#include <morton-nd/mortonND_BMI2.h>
 
 template<typename Ret, typename ...Fields>
 bool TestMortonNDBmiEncoder(type_sequence<Fields...>) {

--- a/test/mortonND_LUT_encoder_test.cpp
+++ b/test/mortonND_LUT_encoder_test.cpp
@@ -1,4 +1,4 @@
-#include <mortonND_LUT_encoder.h>
+#include <morton-nd/mortonND_LUT_encoder.h>
 #include "mortonND_LUT_encoder_test.h"
 #include "mortonND_test_common.h"
 #include "variadic_placeholder.h"


### PR DESCRIPTION
Now, using library headers from another project is done the same way, irrespective of how Morton ND is being consumed (e.g. Git submodule versus through a package manager).

Example:
<morton-nd/mortonND_LUT_encoder.h>

Previously, when consumed as a CMake subproject (BUILD_INTERFACE), headers were not properly inside 'morton-nd' folder.